### PR TITLE
chore: switch build image to ubi after go 1.20 support

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,11 +1,12 @@
-# TODO replace with ubi9/go-toolset once go 1.20 is supported
-FROM docker.io/library/golang:1.20 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20 as builder
 
+USER root
 WORKDIR /mcra
 COPY . .
 RUN make build
+USER default
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
 
 USER root
 COPY --from=builder /mcra/build/mcra /usr/bin/mcra

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ spec:
 Create a _ConfigMap_ named _multicluster-resiliency-addon-config_, setting the target [Hive ClusterPool][pool] for
 claiming new clusters from.
 
-| The _Addon_ takes its configuration from either the _Managed Cluster Namespace_ or the _open-cluster-management_ one.
+| The _Addon_ takes its configuration from either the _Managed Cluster Namespace_ or the _open-cluster-management_ one.<br/>
 | The former will take precedence.
 
 ```yaml
@@ -35,7 +35,7 @@ data:
 
 ## Verify
 
-After installing the _Addon_ in a _Managed Cluster Namespace_, a _ResilientCluster_ reflecting the cluster state is
+After installing the _Addon_ in a _Managed Cluster Namespace_, a _ResilientCluster_ reflecting the cluster status is
 created:
 
 ```shell


### PR DESCRIPTION
- docs: readme typo
- chore: switch build image to ubi9 after go 1.20 support
