### PR TITLE
refactor: using config agent namespace override mca agent namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ kind: ManagedClusterAddOn
 metadata:
   name: multicluster-resiliency-addon
   namespace: "<managed-cluster-name-goes-here>"
-spec:
-  installNamespace: open-cluster-management-agent-addon
 ```
 
 Create a _ConfigMap_ named _multicluster-resiliency-addon-config_, setting the target [Hive ClusterPool][pool] for

--- a/config/samples/managedclusteraddon.yaml
+++ b/config/samples/managedclusteraddon.yaml
@@ -3,5 +3,3 @@ kind: ManagedClusterAddOn
 metadata:
   name: multicluster-resiliency-addon
   namespace: replace-with-cluster-namespace
-spec:
-  installNamespace: open-cluster-management-agent-addon

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -22,6 +22,9 @@ data:
 The agent deployment can be configured using a global _AddonDeploymentConfig_ named
 _multicluster-resiliency-addon-deploy-config_ in the _open-cluster-management_ namespace:
 
+> Note the agent installation namespace on the _Spoke_ can be customized using either the _ManagedClusterAddOn_'s _spec.installNamespace_
+> or the _AddOnDeploymentConfig_'s _spec.agentInstallNamespace_. The latter takes precedence regardless if it global or per-cluster.
+
 ```yaml
 apiVersion: addon.open-cluster-management.io/v1alpha1
 kind: AddOnDeploymentConfig
@@ -29,6 +32,7 @@ metadata:
   name: multicluster-resiliency-addon-deploy-config
   namespace: open-cluster-management
 spec:
+  agentInstallNamespace: open-cluster-management-agent-addon
   customizedVariables:
   - name: AgentReplicas
     value: "1"


### PR DESCRIPTION
Levereging MangedClusterAddOn spec's InstallNamespace and AddonDeploymentConfig spec's
AgentInstallNamespace for setting the agent's install namespace. AddonDeploymentConfig takes
precedence to ManagedClusterAddon.

Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>
