### PR TITLE
fix: resilient cluster should be deleted when a new spoks is ready

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -13,6 +13,7 @@ actions are preformed in order to switch the workload to the new cluster.
 |------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [Compare _ManagedCluster_ Resources][compare-mc]     | Copies labels and annotations from the OLD _MC_ to the NEW one, overriding only the _clusterset_ label. Deletes the OLD _MC_ when done.                             |
 | [Delete Old _ClusterDeployment_][delete-cd]          | Deletes the _ClusterDeployment_ from the OLD Spoke.                                                                                                                 |
+| [Delete Old _ResilientCluster_][delete-rc]           | Deletes the _ResilientCluster_ from the OLD Spoke.                                                                                                                  |
 | [Migrate known _AddonDeploymentConfig_][migrate-adc] | Moves any _AddonDeploymentConfig_ resources associated with the _Addon_'s _ManagedClusterAddon_ from the OLD Spoke to the NEW one.                                  |
 | [Migrate known _ConfigMap_][migrate-cm]              | Moves the _Addon_'s _ConfigMap_ if found, from the OLD Spoke to the NEW one.                                                                                        |
 | [Migrate addon's _ManagedClusterAddon_][migrate-mca] | Moves the _Addon_'s _ManagedClusterAddon_ if found, from the OLD Spoke to the NEW one. If the NEW one was already created by the Addon, the content will be merged. |
@@ -26,6 +27,7 @@ actions are preformed in order to switch the workload to the new cluster.
 <!--ACTIONS-->
 [compare-mc]: ../pkg/controllers/actions/compare_managed_cluster_and_delete_old.go
 [delete-cd]: ../pkg/controllers/actions/delete_old_cluster_deployment.go
+[delete-rc]: ../pkg/controllers/actions/delete_old_resilient_cluster.go
 [migrate-adc]: ../pkg/controllers/actions/migrate_addon_deployment_configs.go
 [migrate-cm]: ../pkg/controllers/actions/migrate_config_map.go
 [migrate-mca]: ../pkg/controllers/actions/migrate_managed_cluster_addon.go

--- a/pkg/controllers/actions/delete_old_cluster_deployment.go
+++ b/pkg/controllers/actions/delete_old_cluster_deployment.go
@@ -2,7 +2,7 @@
 
 package actions
 
-// This file contains the action for deleting a ClusterDeployment from the OLD spoke.
+// This file contains the action for deleting the ClusterDeployment from the OLD spoke.
 
 import (
 	"context"

--- a/pkg/controllers/actions/delete_old_resilient_cluster.go
+++ b/pkg/controllers/actions/delete_old_resilient_cluster.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2023 Red Hat, Inc.
+
+package actions
+
+import (
+	"context"
+	addonv1 "github.com/rhecosystemappeng/multicluster-resiliency-addon/api/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// This file contains the action for deleting the ResilientCluster from the OLD spoke.
+
+// deleteOldResilientCluster is used for deleting Hive's ClusterDeployment from the OLD spoke.
+func deleteOldResilientCluster(ctx context.Context, options Options) {
+	logger := log.FromContext(ctx)
+	logger.Info("deleting old resilient cluster", "old-spoke", options.OldSpoke)
+
+	// the ResilientCluster resides in the cluster-namespace with a matching name
+	oldRCSubject := types.NamespacedName{
+		Namespace: options.OldSpoke,
+		Name:      options.OldSpoke,
+	}
+
+	// fetch ResilientCluster from previous OLD cluster and delete it if exists
+	oldRC := &addonv1.ResilientCluster{}
+	if err := options.Client.Get(ctx, oldRCSubject, oldRC); err != nil {
+		logger.Info("no ResilientCluster found", "old-spoke", options.OldSpoke)
+	} else {
+		if err = options.Client.Delete(ctx, oldRC); err != nil {
+			logger.Error(err, "failed deleting ResilientCluster", "old-spoke", options.OldSpoke)
+		}
+	}
+}
+
+// init is registering deleteOldResilientCluster for running.
+func init() {
+	actionFuncs = append(actionFuncs, deleteOldResilientCluster)
+}


### PR DESCRIPTION
Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>
