### PR TITLE
fix: added update permissions for hive claims

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -146,6 +146,7 @@ rules:
   - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - hive.openshift.io

--- a/pkg/controllers/reconcilers/claim.go
+++ b/pkg/controllers/reconcilers/claim.go
@@ -40,7 +40,7 @@ func (r *ClaimReconciler) setupWithManager(mgr ctrl.Manager) error {
 }
 
 // +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterpools,verbs=get;list;watch
-// +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterclaims,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterclaims,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterclaims/finalizers,verbs=update
 // +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch;create;update;delete


### PR DESCRIPTION
update permissions are required for removing annotations

Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>
