### PR TITLE
fix: typo in status.clustatAvailiability type name

### DIFF
--- a/api/v1/resilientcluster_types.go
+++ b/api/v1/resilientcluster_types.go
@@ -25,14 +25,14 @@ var (
 )
 
 type (
-	// ClustarAvailability is a bool representing whether not the Spoke cluster is available. Use ClusterAvailable and
+	// ClusterAvailability is a bool representing whether not the Spoke cluster is available. Use ClusterAvailable and
 	// ClusterNotAvailable.
-	ClustarAvailability string
+	ClusterAvailability string
 
 	// ClusterStatus represents a status of the Spoke cluster at a specific time.
 	ClusterStatus struct {
 		// +kubebuilder:validation:Enum=True;False
-		Availability ClustarAvailability `json:"availability,omitempty"`
+		Availability ClusterAvailability `json:"availability,omitempty"`
 		Time         metav1.Time         `json:"time,omitempty"`
 	}
 
@@ -67,8 +67,8 @@ type (
 )
 
 const (
-	ClusterAvailable    ClustarAvailability = "True"
-	ClusterNotAvailable ClustarAvailability = "False"
+	ClusterAvailable    ClusterAvailability = "True"
+	ClusterNotAvailable ClusterAvailability = "False"
 )
 
 // init is used for registering the Addon API types with the scheme previously configured with groupVersion.

--- a/config/crd/appeng.ecosystem.redhat.com_resilientclusters.yaml
+++ b/config/crd/appeng.ecosystem.redhat.com_resilientclusters.yaml
@@ -49,7 +49,7 @@ spec:
                   at a specific time.
                 properties:
                   availability:
-                    description: ClustarAvailability is a bool representing whether
+                    description: ClusterAvailability is a bool representing whether
                       not the Spoke cluster is available. Use ClusterAvailable and
                       ClusterNotAvailable.
                     enum:
@@ -65,7 +65,7 @@ spec:
                   at a specific time.
                 properties:
                   availability:
-                    description: ClustarAvailability is a bool representing whether
+                    description: ClusterAvailability is a bool representing whether
                       not the Spoke cluster is available. Use ClusterAvailable and
                       ClusterNotAvailable.
                     enum:
@@ -81,7 +81,7 @@ spec:
                   at a specific time.
                 properties:
                   availability:
-                    description: ClustarAvailability is a bool representing whether
+                    description: ClusterAvailability is a bool representing whether
                       not the Spoke cluster is available. Use ClusterAvailable and
                       ClusterNotAvailable.
                     enum:


### PR DESCRIPTION
chart pr: https://github.com/RHEcosystemAppEng/multicluster-resiliency-addon-chart/pull/9

Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>
